### PR TITLE
Optimize Index Comparisons in Map Generator

### DIFF
--- a/Assets/Scripts/RoguelikeMapGenerator.cs
+++ b/Assets/Scripts/RoguelikeMapGenerator.cs
@@ -90,13 +90,13 @@ public class RoguelikeMapGenerator : MonoBehaviour
         if (currentPos.x < gridwidth - 1 && !roomGrid[currentPos.x + 1, currentPos.y]) {
             openSpots.Add(currentPos + Vector3Int.right);
         }
-        if (currentPos.x > 1 && !roomGrid[currentPos.x - 1, currentPos.y]) {
+        if (currentPos.x > 0 && !roomGrid[currentPos.x - 1, currentPos.y]) {
             openSpots.Add(currentPos - Vector3Int.right);
         }
         if (currentPos.y < gridheight - 1 && !roomGrid[currentPos.x, currentPos.y + 1]) {
             openSpots.Add(currentPos + Vector3Int.up);
         }
-        if (currentPos.y > 1 && !roomGrid[currentPos.x, currentPos.y - 1]) {
+        if (currentPos.y > 0 && !roomGrid[currentPos.x, currentPos.y - 1]) {
             openSpots.Add(currentPos - Vector3Int.up);
         }
 
@@ -112,13 +112,13 @@ public class RoguelikeMapGenerator : MonoBehaviour
             if (currentPos.x < gridwidth - 1 && !roomGrid[currentPos.x + 1, currentPos.y]) {
                 openSpots.Add(currentPos + Vector3Int.right);
             }
-            if (currentPos.x > 1 && !roomGrid[currentPos.x - 1, currentPos.y]) {
+            if (currentPos.x > 0 && !roomGrid[currentPos.x - 1, currentPos.y]) {
                 openSpots.Add(currentPos - Vector3Int.right);
             }
             if (currentPos.y < gridheight - 1 && !roomGrid[currentPos.x, currentPos.y + 1]) {
                 openSpots.Add(currentPos + Vector3Int.up);
             }
-            if (currentPos.y > 1 && !roomGrid[currentPos.x, currentPos.y - 1]) {
+            if (currentPos.y > 0 && !roomGrid[currentPos.x, currentPos.y - 1]) {
                 openSpots.Add(currentPos - Vector3Int.up);
             }
 
@@ -135,9 +135,9 @@ public class RoguelikeMapGenerator : MonoBehaviour
                     Room rPrefab = null;
                     
                     bool up =  (y + 1) < roomGrid.GetLength(1) && roomGrid[x, y + 1];
-                    bool down = (y - 1) > 0 && roomGrid[x, y - 1];
+                    bool down = y > 0 && roomGrid[x, y - 1];
                     bool right = (x + 1) < roomGrid.GetLength(0) && roomGrid[x + 1, y];
-                    bool left = (x - 1) > 0 && roomGrid[x - 1, y];
+                    bool left = x > 0 && roomGrid[x - 1, y];
 
                     RoomConnectionInfo con = new RoomConnectionInfo(up, down, right, left);
 

--- a/Assets/Scripts/Room.cs
+++ b/Assets/Scripts/Room.cs
@@ -31,16 +31,16 @@ public class Room : MonoBehaviour {
 
     internal bool CanFit(bool[,] roomGrid, int x, int y) {
 
-        if (topJoin == null && (y+1) < roomGrid.GetLength(1) && roomGrid[x, y + 1]) {
+        if (topJoin == null && (y + 1) < roomGrid.GetLength(1) && roomGrid[x, y + 1]) {
             return false;
         }
-        if (bottomJoin == null && (y - 1) > 0 && roomGrid[x, y - 1]) {
+        if (bottomJoin == null && y > 0 && roomGrid[x, y - 1]) {
             return false;
         }
         if (rightJoin == null && (x + 1) < roomGrid.GetLength(0) && roomGrid[x + 1, y]) {
             return false;
         }
-        if (leftJoin == null && (x - 1) > 0 && roomGrid[x - 1, y]) {
+        if (leftJoin == null && x > 0 && roomGrid[x - 1, y]) {
             return false;
         }
 


### PR DESCRIPTION
This update will change the row and column index comparisons in order to check for open spots (or filled spots) in row 0 (when a current position's `y` index equals 1) and column 0 (when a current position's `x` index equals 1). The previous index comparisons were technically valid, but I believe they were overly cautious in avoiding IndexOutOfRange exceptions.

If I'm wrong, and these stricter comparisons were done deliberately, then let me know.